### PR TITLE
Add recursive fetching and fix eslint issues

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,64 +1,64 @@
-const liSDK = require("@livingdocs/node-sdk");
-const crypto = require("crypto");
-const resolveIncludes = require("./includes");
-const includesConfig = require("./includes/config");
-const renderLayout = require("./includes/render");
-const slugify = require("./slugify");
+const liSDK = require('@livingdocs/node-sdk')
+const crypto = require('crypto')
+const resolveIncludes = require('./includes')
+const includesConfig = require('./includes/config')
+const renderLayout = require('./includes/render')
+const slugify = require('./slugify')
 const {
   documentTypes,
   defaultDocumentType
-} = require("./includes/config/documentTypes");
+} = require('./includes/config/documentTypes')
 
-exports.sourceNodes = ({ actions }, configOptions) => {
-  const { createNode } = actions;
+exports.sourceNodes = ({actions}, configOptions) => {
+  const {createNode} = actions
 
   // Gatsby adds a configOption that's not needed for this plugin, delete it
-  delete configOptions.plugins;
+  delete configOptions.plugins
 
   // create a new livingdocs-client instance
   const liClient = new liSDK.Client({
-    url: "https://server.livingdocs.io",
+    url: 'https://server.livingdocs.io',
     accessToken: configOptions.accessToken
-  });
+  })
 
-  const limit = configOptions.limit ? configOptions.limit : 10;
+  const limit = configOptions.limit ? configOptions.limit : 10
 
   // get all publications (articles, authors, etc.)
   const getAllPublications = () => {
     const publication = liClient
-      .getPublications({ limit })
-      .then(publications => publications);
-    return publication;
-  };
+      .getPublications({limit})
+      .then(publications => publications)
+    return publication
+  }
 
   const getPublication = async (publication, design) => {
     const livingdoc = liSDK.document.create({
       content: publication.content,
       design
-    });
+    })
 
     if (
-      publication.systemdata.documentType === "article" ||
-      publication.systemdata.documentType === "page"
+      publication.systemdata.documentType === 'article' ||
+      publication.systemdata.documentType === 'page'
     ) {
-      await resolveIncludes(livingdoc, liClient, includesConfig);
+      await resolveIncludes(livingdoc, liClient, includesConfig)
 
-      const documentType = publication.systemdata.documentType;
-      const currentDocumentType = documentTypes && documentTypes[documentType];
-      const targetDocumentType = currentDocumentType || defaultDocumentType;
+      const documentType = publication.systemdata.documentType
+      const currentDocumentType = documentTypes && documentTypes[documentType]
+      const targetDocumentType = currentDocumentType || defaultDocumentType
 
-      const layoutComponents = targetDocumentType.layoutComponents;
-      const html = await renderLayout(livingdoc, design, layoutComponents);
-      return html;
+      const layoutComponents = targetDocumentType.layoutComponents
+      const html = await renderLayout(livingdoc, design, layoutComponents)
+      return html
     } else {
-      const article = liSDK.document.render(livingdoc);
-      return article;
+      const article = liSDK.document.render(livingdoc)
+      return article
     }
-  };
+  }
 
   // Create your node object
   const processPublication = async (publication, design) => {
-    const html = await getPublication(publication, design);
+    const html = await getPublication(publication, design)
     const nodeData = {
       id: `${publication.systemdata.documentId}`,
       parent: `__SOURCE__`,
@@ -75,20 +75,20 @@ exports.sourceNodes = ({ actions }, configOptions) => {
         ),
         html
       }
-    };
-    return nodeData;
-  };
-  async function createNodes() {
-    const allPublications = await getAllPublications();
+    }
+    return nodeData
+  }
+  async function createNodes () {
+    const allPublications = await getAllPublications()
     const design = await liClient.getDesign({
-      name: "living-times",
-      version: "0.0.14"
-    });
+      name: 'living-times',
+      version: '0.0.14'
+    })
     for (const publication of allPublications) {
-      const nodeData = await processPublication(publication, design);
-      createNode(nodeData);
+      const nodeData = await processPublication(publication, design)
+      createNode(nodeData)
     }
   }
 
-  return createNodes();
-};
+  return createNodes()
+}

--- a/includes/config/content_extractor.js
+++ b/includes/config/content_extractor.js
@@ -1,5 +1,5 @@
-const slugify = require("../../slugify");
-const moment = require("moment");
+const slugify = require('../../slugify')
+const moment = require('moment')
 
 module.exports = {
   link,
@@ -11,72 +11,71 @@ module.exports = {
   publishDate,
   profile,
   authorName
-};
-
-function link({ metadata = {}, systemdata = {} } = {}) {
-  return slugify(metadata.title, systemdata.documentId);
 }
 
-function title({ metadata = {} } = {}) {
-  return metadata.title || "";
+function link ({metadata = {}, systemdata = {}} = {}) {
+  return slugify(metadata.title, systemdata.documentId)
 }
 
-function description({ metadata = {} } = {}) {
-  return metadata.description || "";
+function title ({metadata = {}} = {}) {
+  return metadata.title || ''
 }
 
-function profile({ metadata = {} } = {}) {
-  return metadata.profile || "";
+function description ({metadata = {}} = {}) {
+  return metadata.description || ''
 }
 
-function authorName({ metadata = {} } = {}) {
-  if (metadata.prename && metadata.surname)
-    return `${metadata.prename} ${metadata.surname}`;
-  if (metadata.prename) return metadata.prename;
-  if (metadata.surname) return metadata.surname;
-  return "No Name";
+function profile ({metadata = {}} = {}) {
+  return metadata.profile || ''
 }
 
-function image(imageExtractionConfig = {}) {
-  const desiredImageCrop = imageExtractionConfig.crop;
-  const metadataTarget = imageExtractionConfig.target || "teaserImage";
+function authorName ({metadata = {}} = {}) {
+  if (metadata.prename && metadata.surname) { return `${metadata.prename} ${metadata.surname}` }
+  if (metadata.prename) return metadata.prename
+  if (metadata.surname) return metadata.surname
+  return 'No Name'
+}
 
-  return function({ metadata = {} } = {}) {
-    const teaserImage = metadata[metadataTarget];
-    if (!teaserImage) return null;
-    if (!desiredImageCrop) return teaserImage;
-    const crops = teaserImage.crops;
+function image (imageExtractionConfig = {}) {
+  const desiredImageCrop = imageExtractionConfig.crop
+  const metadataTarget = imageExtractionConfig.target || 'teaserImage'
+
+  return function ({metadata = {}} = {}) {
+    const teaserImage = metadata[metadataTarget]
+    if (!teaserImage) return null
+    if (!desiredImageCrop) return teaserImage
+    const crops = teaserImage.crops
     const imageCrop =
-      crops && crops.find(crop => crop.name === desiredImageCrop);
-    if (!imageCrop) return teaserImage;
+      crops && crops.find(crop => crop.name === desiredImageCrop)
+    if (!imageCrop) return teaserImage
     return {
       ...teaserImage,
       url: imageCrop.url,
       width: imageCrop.width,
       height: imageCrop.height
-    };
-  };
+    }
+  }
 }
 
-function flag({ metadata = {} } = {}) {
-  return metadata.flag;
+function flag ({metadata = {}} = {}) {
+  return metadata.flag
 }
 
-function author({ metadata = {} } = {}) {
-  return metadata.author || "";
+function author ({metadata = {}} = {}) {
+  return metadata.author || ''
 }
 
-function publishDate({
+function publishDate ({
   metadata = {},
   first_publication: firstPublication = {}
 } = {}) {
   try {
-    const metadataDate = moment(metadata.publishDate);
-    if (metadataDate.isValid()) return metadataDate.calendar();
-    const recordDate = moment(firstPublication.created_at);
-    if (recordDate.isValid()) return recordDate.calendar();
-    return "";
+    const metadataDate = moment(metadata.publishDate)
+    if (metadataDate.isValid()) return metadataDate.calendar()
+    const recordDate = moment(firstPublication.created_at)
+    if (recordDate.isValid()) return recordDate.calendar()
+    return ''
   } catch (e) {
-    return "";
+    return ''
   }
 }

--- a/includes/config/documentTypes.js
+++ b/includes/config/documentTypes.js
@@ -1,33 +1,33 @@
 const documentTypes = {
   page: {
     layoutComponents: {
-      layout: "page-layout",
-      header: "page-layout-header",
-      headerItem: "page-layout-header-item",
-      footer: "page-layout-footer"
+      layout: 'page-layout',
+      header: 'page-layout-header',
+      headerItem: 'page-layout-header-item',
+      footer: 'page-layout-footer'
     }
   },
   article: {
     layoutComponents: {
-      layout: "article-layout",
-      header: "article-layout-header",
-      headerItem: "article-layout-header-item",
-      footer: "article-layout-footer"
+      layout: 'article-layout',
+      header: 'article-layout-header',
+      headerItem: 'article-layout-header-item',
+      footer: 'article-layout-footer'
     }
   }
-};
+}
 const defaultDocumentType = {
   defaultDocumentType: {
     layoutComponents: {
-      layout: "default-layout",
-      header: "default-layout-header",
-      headerItem: "default-layout-header-item",
-      footer: "default-layout-footer"
+      layout: 'default-layout',
+      header: 'default-layout-header',
+      headerItem: 'default-layout-header-item',
+      footer: 'default-layout-footer'
     }
   }
-};
+}
 
 module.exports = {
   documentTypes,
   defaultDocumentType
-};
+}

--- a/includes/config/enrichments/author_ref.js
+++ b/includes/config/enrichments/author_ref.js
@@ -1,22 +1,22 @@
-const _get = require("lodash/get");
-const slugify = require("../../../slugify");
-const getAuthorPublication = require("./helpers/get_author_publication");
+const _get = require('lodash/get')
+const slugify = require('../../../slugify')
+const getAuthorPublication = require('./helpers/get_author_publication')
 
-module.exports = async function enrichTeaserContentWithAuthor({
+module.exports = async function enrichTeaserContentWithAuthor ({
   liClient,
   publication
 } = {}) {
   const authorPublication = await getAuthorPublication({
     liClient,
     publication
-  });
+  })
 
-  const { metadata, systemdata } = authorPublication;
+  const {metadata, systemdata} = authorPublication
   return {
-    author: `${_get(metadata, "prename")} ${_get(metadata, "surname")}`,
+    author: `${_get(metadata, 'prename')} ${_get(metadata, 'surname')}`,
     authorLink: slugify(
-      _get(metadata, "title", ""),
-      _get(systemdata, "documentId", "")
+      _get(metadata, 'title', ''),
+      _get(systemdata, 'documentId', '')
     )
-  };
-};
+  }
+}

--- a/includes/config/enrichments/author_teaser.js
+++ b/includes/config/enrichments/author_teaser.js
@@ -1,24 +1,24 @@
-const _get = require("lodash/get");
-const slugify = require("../../../slugify");
-const getAuthorPublication = require("./helpers/get_author_publication");
+const _get = require('lodash/get')
+const slugify = require('../../../slugify')
+const getAuthorPublication = require('./helpers/get_author_publication')
 
-module.exports = async function enrichAuthorTeaserContent({
+module.exports = async function enrichAuthorTeaserContent ({
   liClient,
   publication
 } = {}) {
   const authorPublication = await getAuthorPublication({
     liClient,
     publication
-  });
-  if (!authorPublication) return;
+  })
+  if (!authorPublication) return
 
-  const { metadata, systemdata } = authorPublication;
+  const {metadata, systemdata} = authorPublication
   return {
-    title: `${_get(metadata, "prename", "")} ${_get(metadata, "surname", "")}`,
-    image: _get(metadata, "authorImage", ""),
+    title: `${_get(metadata, 'prename', '')} ${_get(metadata, 'surname', '')}`,
+    image: _get(metadata, 'authorImage', ''),
     authorLink: slugify(
-      _get(metadata, "title", ""),
-      _get(systemdata, "documentId", "")
+      _get(metadata, 'title', ''),
+      _get(systemdata, 'documentId', '')
     )
-  };
-};
+  }
+}

--- a/includes/config/enrichments/gallery_teaser.js
+++ b/includes/config/enrichments/gallery_teaser.js
@@ -1,14 +1,14 @@
-const createLivingdoc = require("./helpers/create_livingdoc");
+const createLivingdoc = require('./helpers/create_livingdoc')
 
-module.exports = function enrichGalleryTeaserContent({
+module.exports = function enrichGalleryTeaserContent ({
   component,
   publication
 } = {}) {
-  const galleryLivingdoc = createLivingdoc(publication);
-  const tree = galleryLivingdoc.componentTree;
+  const galleryLivingdoc = createLivingdoc(publication)
+  const tree = galleryLivingdoc.componentTree
 
-  const sourceImages = tree.find("image");
+  const sourceImages = tree.find('image')
   sourceImages.each(imageComponent => {
-    component.append("images", imageComponent);
-  });
-};
+    component.append('images', imageComponent)
+  })
+}

--- a/includes/config/enrichments/video_teaser.js
+++ b/includes/config/enrichments/video_teaser.js
@@ -1,28 +1,28 @@
-const createLivingdoc = require("./helpers/create_livingdoc");
+const createLivingdoc = require('./helpers/create_livingdoc')
 
-module.exports = function enrichVideoTeaserContent({
+module.exports = function enrichVideoTeaserContent ({
   component,
   publication
 } = {}) {
-  const videoLivingdoc = createLivingdoc(publication);
-  const tree = videoLivingdoc.componentTree;
+  const videoLivingdoc = createLivingdoc(publication)
+  const tree = videoLivingdoc.componentTree
 
-  const freeHtmlComponents = tree.find("free-html");
-  const iframeComponents = tree.find("iframe");
+  const freeHtmlComponents = tree.find('free-html')
+  const iframeComponents = tree.find('iframe')
   component.append(
-    "video",
-    getFirstEscaped(freeHtmlComponents, "free-html") ||
-      getFirstEscaped(iframeComponents, "iframe")
-  );
-};
+    'video',
+    getFirstEscaped(freeHtmlComponents, 'free-html') ||
+      getFirstEscaped(iframeComponents, 'iframe')
+  )
+}
 
-function getFirstEscaped(componentModels, directiveName) {
-  if (!componentModels.length) return;
+function getFirstEscaped (componentModels, directiveName) {
+  if (!componentModels.length) return
 
-  const componentModel = componentModels[0];
-  const htmlDirective = componentModel.directives.get(directiveName);
-  const htmlContent = htmlDirective.getContent();
-  htmlDirective.setContent(escape(htmlContent));
+  const componentModel = componentModels[0]
+  const htmlDirective = componentModel.directives.get(directiveName)
+  const htmlContent = htmlDirective.getContent()
+  htmlDirective.setContent(escape(htmlContent))
 
-  return componentModel;
+  return componentModel
 }

--- a/includes/config/index.js
+++ b/includes/config/index.js
@@ -1,42 +1,42 @@
-const contentExtractor = require("./content_extractor");
+const contentExtractor = require('./content_extractor')
 
 module.exports = {
   teaser: {
     layouts: {
-      "author-embed": {
-        template: "teaser-author-template",
+      'author-embed': {
+        template: 'teaser-author-template',
         contentSpec: {
           title: contentExtractor.authorName,
           link: contentExtractor.link,
           authorLink: contentExtractor.link,
           text: contentExtractor.profile,
-          image: contentExtractor.image({ crop: "1:1", target: "authorImage" })
+          image: contentExtractor.image({crop: '1:1', target: 'authorImage'})
         }
       },
-      "sidebar-embed": {
-        template: "teaser-sidebar-template",
+      'sidebar-embed': {
+        template: 'teaser-sidebar-template',
         contentSpec: {
           title: contentExtractor.title,
           link: contentExtractor.link,
           flag: contentExtractor.flag,
           date: contentExtractor.publishDate
         },
-        contentEnrichments: [require("./enrichments/author_ref")]
+        contentEnrichments: [require('./enrichments/author_ref')]
       },
       hero: {
-        template: "teaser-hero-template",
+        template: 'teaser-hero-template',
         contentSpec: {
           title: contentExtractor.title,
           link: contentExtractor.link,
           flag: contentExtractor.flag,
           text: contentExtractor.description,
           date: contentExtractor.publishDate,
-          image: contentExtractor.image({ crop: "16:9" })
+          image: contentExtractor.image({crop: '16:9'})
         },
-        contentEnrichments: [require("./enrichments/author_ref")]
+        contentEnrichments: [require('./enrichments/author_ref')]
       },
       card: {
-        template: "teaser-card-template",
+        template: 'teaser-card-template',
         contentSpec: {
           title: contentExtractor.title,
           link: contentExtractor.link,
@@ -44,12 +44,12 @@ module.exports = {
           flag: contentExtractor.flag,
           text: contentExtractor.description,
           date: contentExtractor.publishDate,
-          image: contentExtractor.image({ crop: "16:9" })
+          image: contentExtractor.image({crop: '16:9'})
         },
-        contentEnrichments: [require("./enrichments/author_ref")]
+        contentEnrichments: [require('./enrichments/author_ref')]
       },
-      "card-no-image": {
-        template: "teaser-card-no-image-template",
+      'card-no-image': {
+        template: 'teaser-card-no-image-template',
         contentSpec: {
           title: contentExtractor.title,
           link: contentExtractor.link,
@@ -57,61 +57,61 @@ module.exports = {
           text: contentExtractor.description,
           date: contentExtractor.publishDate
         },
-        contentEnrichments: [require("./enrichments/author_ref")]
+        contentEnrichments: [require('./enrichments/author_ref')]
       },
-      "card-numbered": {
-        template: "teaser-card-numbered-template",
+      'card-numbered': {
+        template: 'teaser-card-numbered-template',
         contentSpec: {
           title: contentExtractor.title,
           link: contentExtractor.link,
           flag: contentExtractor.flag,
           date: contentExtractor.publishDate
         },
-        contentEnrichments: [require("./enrichments/author_ref")]
+        contentEnrichments: [require('./enrichments/author_ref')]
       },
-      "card-author": {
-        template: "teaser-card-author-template",
+      'card-author': {
+        template: 'teaser-card-author-template',
         contentSpec: {
           link: contentExtractor.link,
           text: contentExtractor.title,
-          image: contentExtractor.image({ crop: "16:9" })
+          image: contentExtractor.image({crop: '16:9'})
         },
-        contentEnrichments: [require("./enrichments/author_teaser")]
+        contentEnrichments: [require('./enrichments/author_teaser')]
       },
       gallery: {
-        template: "teaser-gallery-template",
+        template: 'teaser-gallery-template',
         contentSpec: {
           title: contentExtractor.title,
-          image: contentExtractor.image({ crop: "16:9" })
+          image: contentExtractor.image({crop: '16:9'})
         },
-        contentEnrichments: [require("./enrichments/gallery_teaser")]
+        contentEnrichments: [require('./enrichments/gallery_teaser')]
       },
-      "gallery-hero": {
-        template: "teaser-gallery-hero-template",
+      'gallery-hero': {
+        template: 'teaser-gallery-hero-template',
         contentSpec: {
           title: contentExtractor.title,
           text: contentExtractor.description,
-          image: contentExtractor.image({ crop: "16:9" })
+          image: contentExtractor.image({crop: '16:9'})
         },
-        contentEnrichments: [require("./enrichments/gallery_teaser")]
+        contentEnrichments: [require('./enrichments/gallery_teaser')]
       },
       video: {
-        template: "teaser-video-template",
+        template: 'teaser-video-template',
         contentSpec: {
           title: contentExtractor.title,
-          image: contentExtractor.image({ crop: "16:9" })
+          image: contentExtractor.image({crop: '16:9'})
         },
-        contentEnrichments: [require("./enrichments/video_teaser")]
+        contentEnrichments: [require('./enrichments/video_teaser')]
       },
-      "video-hero": {
-        template: "teaser-video-hero-template",
+      'video-hero': {
+        template: 'teaser-video-hero-template',
         contentSpec: {
           title: contentExtractor.title,
           text: contentExtractor.description,
-          image: contentExtractor.image({ crop: "16:9" })
+          image: contentExtractor.image({crop: '16:9'})
         },
-        contentEnrichments: [require("./enrichments/video_teaser")]
+        contentEnrichments: [require('./enrichments/video_teaser')]
       }
     }
   }
-};
+}

--- a/includes/index.js
+++ b/includes/index.js
@@ -1,42 +1,42 @@
-const liSDK = require("@livingdocs/node-sdk");
+const liSDK = require('@livingdocs/node-sdk')
 
-module.exports = async function resolveIncludes(
+module.exports = async function resolveIncludes (
   livingdoc,
   liClient,
   includesConfig
 ) {
-  const resolverTasks = startResolverTasks(livingdoc, liClient, includesConfig);
+  const resolverTasks = startResolverTasks(livingdoc, liClient, includesConfig)
   for (const task of resolverTasks) {
-    const { serviceName, resolver } = task;
+    const {serviceName, resolver} = task
     try {
-      await resolver;
+      await resolver
     } catch (err) {
       err.message = `Include resolver for "${serviceName}" failed with: ${
         err.message
-      }`;
-      throw err;
+      }`
+      throw err
     }
   }
-};
+}
 
-function startResolverTasks(livingdoc, liClient, includesConfig) {
-  const includeMap = liSDK.document.getIncludes(livingdoc);
+function startResolverTasks (livingdoc, liClient, includesConfig) {
+  const includeMap = liSDK.document.getIncludes(livingdoc)
   return Object.keys(includeMap).map(serviceName => {
     switch (serviceName) {
-      case "teaser":
+      case 'teaser':
         return {
-          serviceName: "teaser",
-          resolver: require("./teaser")({
+          serviceName: 'teaser',
+          resolver: require('./teaser')({
             liClient,
             livingdoc,
-            includes: includeMap["teaser"],
-            includeConfig: includesConfig["teaser"]
+            includes: includeMap['teaser'],
+            includeConfig: includesConfig['teaser']
           })
-        };
+        }
 
       default:
-        const message = `There is no include resolver for service "${serviceName}"`;
-        throw new Error(message);
+        const message = `There is no include resolver for service "${serviceName}"`
+        throw new Error(message)
     }
-  });
+  })
 }

--- a/includes/render.js
+++ b/includes/render.js
@@ -1,13 +1,13 @@
-const liSDK = require("@livingdocs/node-sdk");
+const liSDK = require('@livingdocs/node-sdk')
 
-module.exports = async function renderLayout(livingdoc, design, { layout }) {
-  const wrapperLivingdoc = await liSDK.document.create({ content: {}, design });
+module.exports = async function renderLayout (livingdoc, design, {layout}) {
+  const wrapperLivingdoc = await liSDK.document.create({content: {}, design})
 
-  const tree = wrapperLivingdoc.componentTree;
+  const tree = wrapperLivingdoc.componentTree
 
-  const layoutComponent = tree.createComponent(layout);
-  const contentContainer = layoutComponent.containers.get("content");
-  contentContainer.appendTree(livingdoc.componentTree);
-  tree.append(layoutComponent);
-  return liSDK.document.render(wrapperLivingdoc);
-};
+  const layoutComponent = tree.createComponent(layout)
+  const contentContainer = layoutComponent.containers.get('content')
+  contentContainer.appendTree(livingdoc.componentTree)
+  tree.append(layoutComponent)
+  return liSDK.document.render(wrapperLivingdoc)
+}

--- a/includes/render_include.js
+++ b/includes/render_include.js
@@ -1,54 +1,54 @@
-const liSDK = require("@livingdocs/node-sdk");
+const liSDK = require('@livingdocs/node-sdk')
 
-module.exports = async function renderInclude(
+module.exports = async function renderInclude (
   liClient,
   livingdoc,
   layout,
   includeConfig,
   publication
 ) {
-  const layoutConfig = includeConfig.layouts[layout];
-  const component = livingdoc.createComponent(layoutConfig.template);
+  const layoutConfig = includeConfig.layouts[layout]
+  const component = livingdoc.createComponent(layoutConfig.template)
 
   const includeContent = getIncludeContent(
     layoutConfig.contentSpec,
     publication
-  );
+  )
   const enrichmentArgs = [
     layoutConfig.contentEnrichments,
     liClient,
     component,
     publication
-  ];
-  const enrichments = await getContentEnrichments(...enrichmentArgs);
+  ]
+  const enrichments = await getContentEnrichments(...enrichmentArgs)
 
-  component.setContent({ ...includeContent, ...enrichments });
-  return liSDK.document.renderComponent(component);
-};
-
-function getIncludeContent(contentSpec, publication) {
-  return Object.keys(contentSpec).reduce((accumulator, prop) => {
-    const contentPropExtractor = contentSpec[prop];
-    const accumulatedContent = {};
-    const value = contentPropExtractor(publication);
-    if (value) accumulatedContent[prop] = value;
-    return { ...accumulator, ...accumulatedContent };
-  }, {});
+  component.setContent({...includeContent, ...enrichments})
+  return liSDK.document.renderComponent(component)
 }
 
-async function getContentEnrichments(
+function getIncludeContent (contentSpec, publication) {
+  return Object.keys(contentSpec).reduce((accumulator, prop) => {
+    const contentPropExtractor = contentSpec[prop]
+    const accumulatedContent = {}
+    const value = contentPropExtractor(publication)
+    if (value) accumulatedContent[prop] = value
+    return {...accumulator, ...accumulatedContent}
+  }, {})
+}
+
+async function getContentEnrichments (
   contentEnrichments = [],
   liClient,
   component,
   publication
 ) {
   const pendingEnrichments = contentEnrichments.map(contentEnrichment =>
-    contentEnrichment({ liClient, component, publication })
-  );
-  let enrichments = {};
+    contentEnrichment({liClient, component, publication})
+  )
+  let enrichments = {}
   for (const pendingEnrichment of pendingEnrichments) {
-    const resolvedContentEnrichment = (await pendingEnrichment) || {};
-    enrichments = { ...enrichments, ...resolvedContentEnrichment };
+    const resolvedContentEnrichment = (await pendingEnrichment) || {}
+    enrichments = {...enrichments, ...resolvedContentEnrichment}
   }
-  return enrichments;
+  return enrichments
 }

--- a/includes/teaser.js
+++ b/includes/teaser.js
@@ -1,22 +1,21 @@
-const renderInclude = require("./render_include");
+const renderInclude = require('./render_include')
 
-module.exports = async function resolveEmbedTeaserIncludes({
+module.exports = async function resolveEmbedTeaserIncludes ({
   livingdoc,
   liClient,
   includes,
   includeConfig
 }) {
-  const dataFetchTasks = startDataFetchTasks(includes, liClient);
+  const dataFetchTasks = startDataFetchTasks(includes, liClient)
   for (const task of dataFetchTasks) {
-    const { include, request } = task;
-    const { params } = include.getContent();
+    const {include, request} = task
+    const {params} = include.getContent()
 
-    const layout = params.layout;
-    validateConfig(layout, includeConfig.layouts);
+    const layout = params.layout
+    validateConfig(layout, includeConfig.layouts)
 
-    const publication = await request;
-    if (!publication)
-      throw new Error(`Article embed with id "${params.mediaId}" not found`);
+    const publication = await request
+    if (!publication) { throw new Error(`Article embed with id "${params.mediaId}" not found`) }
 
     const renderArgs = [
       liClient,
@@ -24,39 +23,39 @@ module.exports = async function resolveEmbedTeaserIncludes({
       layout,
       includeConfig,
       publication
-    ];
+    ]
 
-    const html = await renderInclude(...renderArgs);
+    const html = await renderInclude(...renderArgs)
 
     // exclude includes that werent found, and include the html of resolved includes
-    !publication.error && include.resolve(html);
+    !publication.error && include.resolve(html)
   }
-};
-
-function startDataFetchTasks(includes, liClient) {
-  return includes
-    .filter(include => {
-      const { params } = include.getContent();
-      return !!params.mediaId;
-    })
-    .map(include => {
-      const { params } = include.getContent();
-
-      const request = liClient.getPublication({ documentId: params.mediaId });
-      return { include, request };
-    });
 }
 
-function validateConfig(layout, layoutsConfig) {
-  const layoutConfig = layoutsConfig[layout];
+function startDataFetchTasks (includes, liClient) {
+  return includes
+    .filter(include => {
+      const {params} = include.getContent()
+      return !!params.mediaId
+    })
+    .map(include => {
+      const {params} = include.getContent()
+
+      const request = liClient.getPublication({documentId: params.mediaId})
+      return {include, request}
+    })
+}
+
+function validateConfig (layout, layoutsConfig) {
+  const layoutConfig = layoutsConfig[layout]
   if (!layoutConfig.template) {
     throw new Error(
       `Template component ("template") for layout "${layout}" not specified in layout configuration`
-    );
+    )
   }
   if (!layoutConfig.contentSpec) {
     throw new Error(
       `Content spec ("contentSpec") for layout "${layout}" not specified in layout configuration`
-    );
+    )
   }
 }

--- a/slugify.js
+++ b/slugify.js
@@ -3,11 +3,11 @@ const slugify = text => {
     .toString()
     .toLowerCase()
     .trim()
-    .replace(/&/g, "-and-") // Replace & with 'and'
-    .replace(/[\s\W-]+/g, "-") // Replace spaces, non-word characters and dashes with a single dash (-)
-    .replace(/-$/, ""); // Remove last floating dash if exists
-};
+    .replace(/&/g, '-and-') // Replace & with 'and'
+    .replace(/[\s\W-]+/g, '-') // Replace spaces, non-word characters and dashes with a single dash (-)
+    .replace(/-$/, '') // Remove last floating dash if exists
+}
 
 module.exports = (title, documentId) => {
-  return title && `${slugify(title)}-${documentId}`;
-};
+  return title && `${slugify(title)}-${documentId}`
+}


### PR DESCRIPTION
## Motivation
We want to be able to fetch documents beyond a given limit.

**Use-case:** You have 1000 documents, but the current limit is 100. As a service user, this can be disrupting and in the case of using gatsby is not wished. Now it will recursively fetch all documents using the "offset" parameter in the requests

_Bonus: Eslint issues have been fixed_